### PR TITLE
docs: add OpenPortal install badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ wall display that syncs everyone's Google and Apple calendars, color-coded per p
 with two-way event creation. Think Skylight-style family board, built from a $30
 secondhand Portal.
 
+[![Get it on OpenPortal](https://andronedev.github.io/openportal/openportal-badge.svg)](https://andronedev.github.io/openportal/apps/com.portal.calendar)
+
 | Week board | Month board |
 |---|---|
 | ![Week view](docs/week-view.png) | ![Month view](docs/month-view.png) |
@@ -51,6 +53,11 @@ Portal reboot (no root means it can't be persisted) — replug USB and re-run
 `adb tcpip 5555` after a restart.
 
 That's it. The board shows a QR code; everything else happens from your phone.
+
+**No `adb`?** You can install straight from your browser with
+[OpenPortal](https://andronedev.github.io/openportal/apps/com.portal.calendar) — plug
+the Portal into any Chromium-based browser via USB, click install, and skip the
+`adb` commands above. No driver or toolchain needed.
 
 > **10″ Portal / text too small?** There's a **Display size** control on the setup
 > page (and under ⚙ on the board) that zooms the whole UI from 80% to 140%.


### PR DESCRIPTION
Hi! 👋 Portal Calendar is featured in [**OpenPortal**](https://andronedev.github.io/openportal/), a browser-based tool that manages Meta Portal devices over WebUSB + ADB — no app, no drivers, no backend. It has a community app catalog, and Portal Calendar is in it (flagged "Made for Portal").

This PR proposes adding the OpenPortal install badge to your README so visitors can install Portal Calendar **straight from their browser**, without needing `adb`.

### What's in the diff

- **Badge** under the intro:

  [![Get it on OpenPortal](https://andronedev.github.io/openportal/openportal-badge.svg)](https://andronedev.github.io/openportal/apps/com.portal.calendar)

- A short **"No `adb`?"** note in the **Install** section pointing to the browser install path as an alternative to the `adb install` commands.

### Why it might help

Your install path currently needs a machine with `adb`. OpenPortal lets users plug the Portal into any Chromium-based browser and one-click install — the Portal downloads the APK from your GitHub releases itself (no backend/CORS proxy), so it's just another front door to the same `portal-calendar-vx.x.apk`.

Totally your call on placement (or whether to take it at all) — happy to adjust wording, move the badge, or drop the install note if you'd rather keep it minimal. The badge SVG and the catalog page are live. Thanks for building this! 🙏