### PR TITLE
Keep only the iCal properties the board reads, before parsing

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -36,4 +36,6 @@ dependencies {
   implementation("net.sf.biweekly:biweekly:0.6.8")
   // CalDAV (PROPFIND/PUT) — HttpURLConnection can't send PROPFIND.
   implementation("com.squareup.okhttp3:okhttp:4.12.0")
+  // JVM unit tests for pure logic (e.g. IcsFilter).
+  testImplementation("junit:junit:4.13.2")
 }

--- a/app/src/main/java/com/portal/calendar/IcsFilter.kt
+++ b/app/src/main/java/com/portal/calendar/IcsFilter.kt
@@ -1,0 +1,69 @@
+package com.portal.calendar
+
+/**
+ * Reduces an iCalendar feed to just the properties the board reads, before biweekly parses it.
+ * A feed dominated by data we never use (attendee lists, descriptions, attachments) otherwise
+ * wastes most of the parse; keeping only the needed properties shrinks it and cuts parse time
+ * proportionally.
+ *
+ * It's an allowlist ([EVENT_PROPERTIES]), not a denylist: a new field a provider invents is
+ * dropped automatically rather than chased. Pure, JVM-testable, and fold-aware (a property
+ * continues on any following line that starts with a space or tab).
+ */
+object IcsFilter {
+    /** The VEVENT properties the board reads — the single source of truth (see SyncManager.
+     *  parseFeed). Add one here when parseFeed starts reading it; nothing else changes. */
+    val EVENT_PROPERTIES = setOf(
+        "SUMMARY", "DTSTART", "DTEND", "DURATION", "LOCATION",
+        "UID", "RRULE", "RDATE", "EXDATE", "RECURRENCE-ID", "STATUS",
+    )
+
+    fun keepNeededProperties(ics: String): String {
+        val sb = StringBuilder(ics.length / 2)
+        // Stack of open component names. A property is dropped only when its enclosing component
+        // is a VEVENT and it isn't in EVENT_PROPERTIES; VCALENDAR headers, VTIMEZONE and VALARM
+        // are kept. BEGIN/END are always emitted, so the output's structure matches the input's
+        // and even a malformed/unbalanced feed can't be corrupted into one biweekly rejects.
+        val stack = ArrayList<String>()
+        var keepingFold = true  // are the current property's continuation lines kept?
+
+        for (rawLine in ics.splitToSequence('\n')) {
+            val line = if (rawLine.endsWith('\r')) rawLine.dropLast(1) else rawLine
+            if (line.isNotEmpty() && (line[0] == ' ' || line[0] == '\t')) {
+                if (keepingFold) sb.append(line).append("\r\n")
+                continue
+            }
+            when (val name = propName(line)) {
+                "BEGIN" -> {
+                    stack.add(valueOf(line))
+                    keepingFold = true
+                    sb.append(line).append("\r\n")
+                }
+                "END" -> {
+                    if (stack.isNotEmpty()) stack.removeAt(stack.size - 1)
+                    keepingFold = true
+                    sb.append(line).append("\r\n")
+                }
+                else -> {
+                    keepingFold = stack.lastOrNull() != "VEVENT" || name in EVENT_PROPERTIES
+                    if (keepingFold) sb.append(line).append("\r\n")
+                }
+            }
+        }
+        return sb.toString()
+    }
+
+    /** Property name = text before the first ':' or ';' (params), upper-cased. */
+    private fun propName(line: String): String {
+        var end = line.length
+        for (i in line.indices) {
+            val c = line[i]
+            if (c == ':' || c == ';') { end = i; break }
+        }
+        return line.substring(0, end).uppercase()
+    }
+
+    /** Component name on a BEGIN/END line: text after the first ':', upper-cased. */
+    private fun valueOf(line: String): String =
+        line.substringAfter(':', "").trim().uppercase()
+}

--- a/app/src/main/java/com/portal/calendar/SyncManager.kt
+++ b/app/src/main/java/com/portal/calendar/SyncManager.kt
@@ -70,9 +70,11 @@ class SyncManager(private val ctx: Context, private val store: ConfigStore) {
             try {
                 if (conn.responseCode !in 200..299)
                     throw RuntimeException("HTTP ${conn.responseCode}")
-                val text = conn.inputStream.bufferedReader().readText()
-                if (!text.contains("BEGIN:VCALENDAR"))
+                val raw = conn.inputStream.bufferedReader().readText()
+                if (!raw.contains("BEGIN:VCALENDAR"))
                     throw RuntimeException("not an iCal feed")
+                // Drop properties the board never reads before caching/parsing (see IcsFilter).
+                val text = IcsFilter.keepNeededProperties(raw)
                 // Atomic: a crash mid-write must not corrupt the offline copy.
                 val tmp = File(cache.path + ".tmp")
                 tmp.writeText(text)

--- a/app/src/test/java/com/portal/calendar/IcsFilterTest.kt
+++ b/app/src/test/java/com/portal/calendar/IcsFilterTest.kt
@@ -1,0 +1,155 @@
+package com.portal.calendar
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for the pre-parse property allowlist. No Android dependencies — runs on the JVM.
+ */
+class IcsFilterTest {
+
+    private fun keep(s: String) = IcsFilter.keepNeededProperties(s)
+
+    @Test fun keepsTheNeededEventPropertiesAndDropsAttendee() {
+        val ics = listOf(
+            "BEGIN:VCALENDAR",
+            "BEGIN:VEVENT",
+            "UID:abc-123",
+            "SUMMARY:Standup",
+            "DTSTART:20260629T160000Z",
+            "DTEND:20260629T163000Z",
+            "LOCATION:Room 4",
+            "ATTENDEE;CN=Alice:mailto:alice@example.com",
+            "RRULE:FREQ=WEEKLY",
+            "END:VEVENT",
+            "END:VCALENDAR",
+        ).joinToString("\r\n")
+        val out = keep(ics)
+        assertFalse("attendee dropped", out.contains("ATTENDEE"))
+        for (p in listOf("UID:abc-123", "SUMMARY:Standup", "DTSTART:", "DTEND:", "LOCATION:Room 4", "RRULE:FREQ=WEEKLY"))
+            assertTrue("kept $p", out.contains(p))
+    }
+
+    @Test fun dropsAnyUnknownEventPropertyAutomatically() {
+        // The allowlist's whole point: a property the parser doesn't read is dropped without
+        // having to be named — a future provider field needs no code change here.
+        val ics = "BEGIN:VEVENT\r\nSUMMARY:x\r\nX-SOME-NEW-FIELD:huge payload\r\nDESCRIPTION:body\r\nEND:VEVENT"
+        val out = keep(ics)
+        assertTrue(out.contains("SUMMARY:x"))
+        assertFalse(out.contains("X-SOME-NEW-FIELD"))
+        assertFalse(out.contains("DESCRIPTION:body"))
+    }
+
+    @Test fun dropsFoldedContinuationLinesOfaDroppedProperty() {
+        val ics = listOf(
+            "BEGIN:VEVENT",
+            "ATTENDEE;CN=Somebody With A Very Long Name:mailto:somebody",
+            " .with.a.long.address@example.com",
+            "\t-and-a-tab-folded-tail",
+            "SUMMARY:After the fold",
+            "END:VEVENT",
+        ).joinToString("\r\n")
+        val out = keep(ics)
+        assertFalse(out.contains("ATTENDEE"))
+        assertFalse("continuation gone", out.contains("long.address"))
+        assertFalse("tab continuation gone", out.contains("tab-folded-tail"))
+        assertTrue("real prop after fold kept", out.contains("SUMMARY:After the fold"))
+    }
+
+    @Test fun keepsFoldedContinuationOfaKeptProperty() {
+        val ics = listOf(
+            "BEGIN:VEVENT",
+            "SUMMARY:A title that is",
+            " folded across two lines",
+            "END:VEVENT",
+        ).joinToString("\r\n")
+        val out = keep(ics)
+        assertTrue(out.contains("SUMMARY:A title that is"))
+        assertTrue("kept prop keeps its fold", out.contains(" folded across two lines"))
+    }
+
+    @Test fun keepsVtimezoneVerbatimIncludingItsRules() {
+        // VTIMEZONE carries TZOFFSET/RRULE for DST and is NOT a VEVENT, so it's kept whole —
+        // even properties not on the event allowlist (TZOFFSETFROM/TO).
+        val ics = listOf(
+            "BEGIN:VCALENDAR",
+            "BEGIN:VTIMEZONE",
+            "TZID:America/Los_Angeles",
+            "BEGIN:DAYLIGHT",
+            "TZOFFSETFROM:-0800",
+            "TZOFFSETTO:-0700",
+            "RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU",
+            "END:DAYLIGHT",
+            "END:VTIMEZONE",
+            "END:VCALENDAR",
+        ).joinToString("\r\n")
+        val out = keep(ics)
+        for (p in listOf("TZID:America/Los_Angeles", "TZOFFSETFROM:-0800", "TZOFFSETTO:-0700",
+                "RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU", "BEGIN:DAYLIGHT", "END:VTIMEZONE"))
+            assertTrue("kept $p", out.contains(p))
+    }
+
+    @Test fun keepsValarmSubBlockVerbatimButStillDropsTheEventsOwnBloat() {
+        // VALARM is a sub-component, not a direct VEVENT property: kept whole so BEGIN/END
+        // stay balanced. Only the event's own non-allowlisted properties (ATTENDEE) are removed.
+        val ics = listOf(
+            "BEGIN:VEVENT",
+            "SUMMARY:Meeting",
+            "ATTENDEE;CN=A:mailto:a@example.com",
+            "BEGIN:VALARM",
+            "ACTION:DISPLAY",
+            "TRIGGER:-PT10M",
+            "END:VALARM",
+            "DTSTART:20260629T160000Z",
+            "END:VEVENT",
+        ).joinToString("\r\n")
+        val out = keep(ics)
+        assertTrue(out.contains("SUMMARY:Meeting"))
+        assertTrue(out.contains("DTSTART:20260629T160000Z"))
+        assertFalse("the event's own attendee is still dropped", out.contains("ATTENDEE"))
+        assertTrue("VALARM kept verbatim", out.contains("BEGIN:VALARM"))
+        assertTrue(out.contains("ACTION:DISPLAY"))
+        assertTrue(out.contains("TRIGGER:-PT10M"))
+        assertTrue(out.contains("END:VALARM"))
+    }
+
+    @Test fun malformedUnbalancedComponentsDoNotCorruptStructure() {
+        // Regression: a VALARM missing its END must not swallow END:VEVENT or merge events.
+        // Every BEGIN/END is emitted verbatim, so the filtered structure mirrors the input
+        // exactly and biweekly sees the same (recoverable) tree it would have on the raw feed.
+        val ics = listOf(
+            "BEGIN:VCALENDAR",
+            "BEGIN:VEVENT", "UID:1", "SUMMARY:A",
+            "BEGIN:VALARM", "ACTION:DISPLAY",   // <- no END:VALARM
+            "END:VEVENT",
+            "BEGIN:VEVENT", "UID:2", "SUMMARY:B",
+            "END:VEVENT",
+            "END:VCALENDAR",
+        ).joinToString("\r\n")
+        val out = keep(ics)
+        assertEquals("both events' opens survive", 2, Regex("(?m)^BEGIN:VEVENT").findAll(out).count())
+        assertEquals("both events' closes survive", 2, Regex("(?m)^END:VEVENT").findAll(out).count())
+        assertTrue(out.contains("UID:1"))
+        assertTrue(out.contains("UID:2"))
+        assertTrue("the unbalanced VALARM open is preserved, not silently consumed", out.contains("BEGIN:VALARM"))
+    }
+
+    @Test fun keepsVcalendarLevelHeaders() {
+        // Top-level (non-VEVENT) properties — VERSION, PRODID, X-WR-TIMEZONE — are kept.
+        val ics = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Test//EN\r\nX-WR-TIMEZONE:America/Los_Angeles\r\nEND:VCALENDAR"
+        val out = keep(ics)
+        assertTrue(out.contains("VERSION:2.0"))
+        assertTrue(out.contains("PRODID:-//Test//EN"))
+        assertTrue(out.contains("X-WR-TIMEZONE:America/Los_Angeles"))
+    }
+
+    @Test fun matchesPropertyNameNotValue() {
+        // A SUMMARY whose value contains "DESCRIPTION" survives; the DESCRIPTION property doesn't.
+        val ics = "BEGIN:VEVENT\r\nSUMMARY:Job description review\r\nDESCRIPTION:long body\r\nEND:VEVENT"
+        val out = keep(ics)
+        assertTrue(out.contains("SUMMARY:Job description review"))
+        assertFalse(out.contains("DESCRIPTION:long body"))
+    }
+}


### PR DESCRIPTION
Pre-filter each iCal feed to keep only the properties the board reads, before biweekly parses it.

Feeds can be dominated by data the board never reads — attendee lists, descriptions, attachments — and biweekly parsed all of it just to discard it, which dominated sync.

`IcsFilter.keepNeededProperties` is applied in `fetchWithCache`, so the on-disk cache shrinks too.

Tested: `IcsFilterTest` unit tests, plus on-device verification against live feeds — cache size and parse time both dropped substantially, total sync time cut markedly, event count unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)