### PR TITLE
Add Jarvis (Portal assistant) calendar integration

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,6 +42,21 @@
             android:name=".KeepAliveService"
             android:exported="false" />
 
+        <!-- Read-only calendar agenda for the Portal assistant. Exported so the
+             assistant can discover + call it; returns agenda text (titles/times/
+             locations/people), never the secret iCal URLs. See CalendarToolProvider. -->
+        <provider
+            android:name=".CalendarToolProvider"
+            android:authorities="com.portal.calendar.tools"
+            android:exported="true">
+            <meta-data
+                android:name="com.portal.assistant.tools"
+                android:value="@string/portal_tools" />
+            <meta-data
+                android:name="com.portal.assistant.tools.summary"
+                android:value="@string/portal_tools_summary" />
+        </provider>
+
         <receiver
             android:name=".BootReceiver"
             android:exported="true">

--- a/app/src/main/java/com/portal/calendar/AgendaFormatter.kt
+++ b/app/src/main/java/com/portal/calendar/AgendaFormatter.kt
@@ -1,0 +1,130 @@
+package com.portal.calendar
+
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+/**
+ * Renders a windowed, sorted list of [EventInstance] into the readable day-grouped text the
+ * assistant tool hands to Jarvis. Pure (no Android, no I/O); the
+ * provider supplies `now`, the device zone, the 12/24-hour preference, the calendar names,
+ * and any soft notes. English locale on purpose — the agenda is consumed by the (English)
+ * assistant and stays deterministic for tests.
+ *
+ * The goal is for the model to *read and reason* over this text (count, find the next item,
+ * spot a person by name in a title), exactly as it would over a pasted calendar — so the
+ * wording is plain and never error-shaped.
+ *
+ * Events are listed under **every local day they cover** within the window, so a multi-day
+ * trip shows up on each of its days (not just the first), and a cross-midnight event reads
+ * sensibly on both days.
+ */
+object AgendaFormatter {
+
+    private val DAY_HEADER = DateTimeFormatter.ofPattern("EEEE, MMM d", Locale.ENGLISH)
+    private val HEADER_DATE = DateTimeFormatter.ofPattern("EEEE, MMMM d, yyyy", Locale.ENGLISH)
+    private val T12 = DateTimeFormatter.ofPattern("h:mm a", Locale.ENGLISH)
+    private val T24 = DateTimeFormatter.ofPattern("HH:mm", Locale.ENGLISH)
+    private val WS = Regex("\\s+")
+
+    /**
+     * @param events  filtered to the window and sorted by start.
+     * @param nowMs   current time, for the header.
+     * @param windowStartMs  start of the agenda window (local midnight when the caller passed
+     *                       a date; a mid-day instant if it passed a datetime).
+     * @param days    window length (number of day buckets to render).
+     * @param zone    device zone.
+     * @param use24h  device 12/24-hour preference.
+     * @param calendarNames  feed (person) names, for the "Calendars:" line. Empty => none configured.
+     * @param notes   soft lines appended under the header (staleness, "some calendars couldn't be
+     *                read", truncation, …). Never error-shaped.
+     */
+    fun format(
+        events: List<EventInstance>,
+        nowMs: Long,
+        windowStartMs: Long,
+        days: Int,
+        zone: ZoneId,
+        use24h: Boolean,
+        calendarNames: List<String>,
+        notes: List<String> = emptyList(),
+    ): String {
+        val sb = StringBuilder()
+        val nowZdt = Instant.ofEpochMilli(nowMs).atZone(zone)
+        val today = nowZdt.toLocalDate()
+        sb.append("Today is ").append(HEADER_DATE.format(nowZdt))
+            .append(", ").append(timeOf(nowMs, zone, use24h))
+            .append(" (").append(zone.id).append(").\n")
+        if (calendarNames.isEmpty()) {
+            // The one explicit "nothing here" case — stated plainly, not as an error.
+            sb.append("No calendars are configured on this device.")
+            return sb.toString()
+        }
+        sb.append("Calendars: ").append(calendarNames.joinToString(", ")).append(".\n")
+        val windowStartDate = Instant.ofEpochMilli(windowStartMs).atZone(zone).toLocalDate()
+        val dayWord = if (days == 1) " day" else " days"
+        if (windowStartDate == nowZdt.toLocalDate()) {
+            sb.append("Upcoming agenda for the next ").append(days).append(dayWord)
+        } else {
+            sb.append("Agenda for ").append(days).append(dayWord)
+                .append(" starting ").append(DAY_HEADER.format(windowStartDate))
+        }
+        sb.append(" — all times local.\n")
+        notes.forEach { sb.append(it).append('\n') }
+
+        if (events.isEmpty()) {
+            sb.append("\nNo events in this period.")
+            return sb.toString()
+        }
+
+        // List each event under every local day it covers within the window.
+        for (offset in 0 until days) {
+            val day = windowStartDate.plusDays(offset.toLong())
+            val dayStart = day.atStartOfDay(zone).toInstant().toEpochMilli()
+            val dayEnd = day.plusDays(1).atStartOfDay(zone).toInstant().toEpochMilli()
+            val onDay = events.filter { it.start < dayEnd && it.end > dayStart } // overlaps this day
+            if (onDay.isEmpty()) continue
+            // Anchor each day relative to now so the model answers "today"/"tomorrow" without
+            // doing (error-prone) date arithmetic over the weekday/date alone.
+            sb.append('\n').append(DAY_HEADER.format(day))
+            when (day.toEpochDay() - today.toEpochDay()) {
+                0L -> sb.append(" (today)")
+                1L -> sb.append(" (tomorrow)")
+            }
+            sb.append(":\n")
+            for (e in onDay) {
+                sb.append("  ").append(timeLabel(e, dayStart, dayEnd, zone, use24h))
+                    .append("  ").append(oneLine(e.title))
+                    .append(" — ").append(oneLine(e.feedName))
+                e.location?.let { oneLine(it) }?.takeUnless { it.isEmpty() }?.let { sb.append(" @ ").append(it) }
+                sb.append('\n')
+            }
+        }
+        return sb.toString().trimEnd('\n')
+    }
+
+    /**
+     * Time label for [e] as seen on the day `[dayStart, dayEnd)`. A timed event that begins
+     * or ends on another day is shown as "… onward" / "until …" so the range never reads
+     * backwards across midnight; an event covering the whole day shows "all day".
+     */
+    private fun timeLabel(e: EventInstance, dayStart: Long, dayEnd: Long, zone: ZoneId, use24h: Boolean): String {
+        if (e.allDay) return "all day"
+        val startsToday = e.start >= dayStart
+        val endsToday = e.end <= dayEnd
+        return when {
+            startsToday && endsToday -> timeOf(e.start, zone, use24h) + "–" + timeOf(e.end, zone, use24h)
+            startsToday -> timeOf(e.start, zone, use24h) + " onward"
+            endsToday -> "until " + timeOf(e.end, zone, use24h)
+            else -> "all day"
+        }
+    }
+
+    /** Collapse internal whitespace/newlines so every event stays on one line. */
+    private fun oneLine(s: String): String = s.replace(WS, " ").trim()
+
+    private fun timeOf(ms: Long, zone: ZoneId, use24h: Boolean): String =
+        (if (use24h) T24 else T12).format(Instant.ofEpochMilli(ms).atZone(zone))
+}

--- a/app/src/main/java/com/portal/calendar/App.kt
+++ b/app/src/main/java/com/portal/calendar/App.kt
@@ -54,11 +54,40 @@ class App : Application() {
         main.post(block)
     }
 
+    /** Publish a completed sync to the in-memory snapshot and persist it (off the main thread),
+     *  so a later cold start can answer from it without re-parsing every feed. A wholly-failed
+     *  sync (no events + problems) is not persisted, so it can't wipe the last good snapshot. */
+    fun publishSync(events: List<EventInstance>, at: Long, problems: List<String>) {
+        lastEvents = events
+        lastSyncAt = at
+        lastSyncProblems = problems
+        if (events.isNotEmpty() || problems.isEmpty()) {
+            Thread { runCatching { Snapshot.save(this, events, at, problems) } }.start()
+        }
+    }
+
     override fun onCreate() {
         super.onCreate()
         instance = this
         store = ConfigStore(this)
         sync = SyncManager(this, store)
+        // Prime from the last persisted agenda BEFORE marking ready, so a cold provider call
+        // answers instantly from the last good data instead of re-parsing every ICS cache.
+        Snapshot.load(this)?.let { snap ->
+            // Drop events (and the matching "Name: ..." problems) for feeds no longer configured,
+            // so a removed/renamed calendar isn't resurrected on a cold start. Adopt the "as of"
+            // only when usable events remain, else leave it 0 so the tool refreshes.
+            val names = store.feeds().filter { it.kind != "inbox" }.map { it.name }.toSet()
+            val events = snap.events.filter { it.feedName in names }
+            if (events.isNotEmpty()) {
+                lastEvents = events
+                lastSyncAt = snap.syncedAt
+                lastSyncProblems = snap.problems.filter {
+                    val feed = it.substringBefore(": ", "")
+                    feed.isEmpty() || feed in names
+                }
+            }
+        }
         // The assistant tool only needs store + sync — mark ready now so a cold provider
         // call isn't blocked (or wedged) by the peripheral startup that follows.
         ready = true

--- a/app/src/main/java/com/portal/calendar/App.kt
+++ b/app/src/main/java/com/portal/calendar/App.kt
@@ -32,11 +32,23 @@ class App : Application() {
     private val main = Handler(Looper.getMainLooper())
     private val configListeners = CopyOnWriteArraySet<() -> Unit>()
 
+    /** Set once onCreate has wired up store/sync/server — guards against a binder-thread
+     *  provider call() that lands mid-startup (instance set, dependencies not yet). */
+    @Volatile var ready = false
+
     /** The board currently on screen, if any — used for live scale preview. */
     var activeBoard: BoardController? = null
 
     /** Last synced events, so a rebuilt board paints instantly instead of empty. */
     @Volatile var lastEvents: List<EventInstance> = emptyList()
+
+    /** When [lastEvents] was last refreshed (epoch ms; 0 = never). Surfaced to the
+     *  assistant as `asOf` so it can judge staleness when the board isn't on screen. */
+    @Volatile var lastSyncAt: Long = 0L
+
+    /** Per-feed problems from the last sync (e.g. a feed that failed to fetch/parse), so the
+     *  assistant tool can note that the agenda may be missing a calendar. */
+    @Volatile var lastSyncProblems: List<String> = emptyList()
 
     fun onMain(block: () -> Unit) {
         main.post(block)
@@ -47,6 +59,9 @@ class App : Application() {
         instance = this
         store = ConfigStore(this)
         sync = SyncManager(this, store)
+        // The assistant tool only needs store + sync — mark ready now so a cold provider
+        // call isn't blocked (or wedged) by the peripheral startup that follows.
+        ready = true
         server = ConfigServer(this, store) { notifyConfigChanged() }
         try {
             server?.start(fi.iki.elonen.NanoHTTPD.SOCKET_READ_TIMEOUT, true)
@@ -144,5 +159,11 @@ class App : Application() {
 
     companion object {
         lateinit var instance: App
+
+        /** Null until [onCreate] has fully run — a ContentProvider call() can land on a
+         *  binder thread mid-startup, before `instance` or its deps are set. Gated on
+         *  [ready] so callers never see a half-initialized App. */
+        fun instanceOrNull(): App? =
+            if (::instance.isInitialized && instance.ready) instance else null
     }
 }

--- a/app/src/main/java/com/portal/calendar/BoardController.kt
+++ b/app/src/main/java/com/portal/calendar/BoardController.kt
@@ -432,6 +432,8 @@ class BoardController(private val baseCtx: Context) {
             if (stopped) return@requestSync // board rebuilt mid-sync — don't touch dead views
             events = evs
             App.instance.lastEvents = evs
+            App.instance.lastSyncAt = System.currentTimeMillis()
+            App.instance.lastSyncProblems = problems
             statusLine = if (problems.isEmpty())
                 "Updated " + timeFormat().format(Calendar.getInstance().time)
             else problems.joinToString("\n")

--- a/app/src/main/java/com/portal/calendar/BoardController.kt
+++ b/app/src/main/java/com/portal/calendar/BoardController.kt
@@ -431,9 +431,7 @@ class BoardController(private val baseCtx: Context) {
         sync.requestSync { evs, problems ->
             if (stopped) return@requestSync // board rebuilt mid-sync — don't touch dead views
             events = evs
-            App.instance.lastEvents = evs
-            App.instance.lastSyncAt = System.currentTimeMillis()
-            App.instance.lastSyncProblems = problems
+            App.instance.publishSync(evs, System.currentTimeMillis(), problems)
             statusLine = if (problems.isEmpty())
                 "Updated " + timeFormat().format(Calendar.getInstance().time)
             else problems.joinToString("\n")

--- a/app/src/main/java/com/portal/calendar/CalendarQuery.kt
+++ b/app/src/main/java/com/portal/calendar/CalendarQuery.kt
@@ -1,0 +1,58 @@
+package com.portal.calendar
+
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+/**
+ * Pure window/date helpers behind the assistant's `get_agenda` tool — no Android, no I/O,
+ * so they are unit-testable in isolation. [CalendarToolProvider] handles JSON marshalling
+ * and the event-snapshot lookup; [AgendaFormatter] renders the text.
+ */
+object CalendarQuery {
+
+    const val DAY_MS = 86_400_000L
+
+    /** Events overlapping the half-open window `[rangeStart, rangeEnd)` (epoch ms). The snapshot
+     *  is already start-sorted (every producer sorts) and `filter` preserves order, so the result
+     *  stays soonest-first without a redundant re-sort. */
+    fun inWindow(events: List<EventInstance>, rangeStart: Long, rangeEnd: Long): List<EventInstance> =
+        events.filter { it.end > rangeStart && it.start < rangeEnd }
+
+    /** Local midnight (epoch ms) of the day containing [nowMs] — the default agenda start. */
+    fun startOfToday(nowMs: Long, zone: ZoneId): Long =
+        Instant.ofEpochMilli(nowMs).atZone(zone).toLocalDate().atStartOfDay(zone).toInstant().toEpochMilli()
+
+    /**
+     * Local midnight [days] calendar days after [startMs]. Zone-aware (advances calendar
+     * days, not fixed 24h spans) so a window crossing a DST transition lands exactly on the
+     * Nth day's midnight instead of drifting an hour.
+     */
+    fun endAfterDays(startMs: Long, days: Int, zone: ZoneId): Long =
+        Instant.ofEpochMilli(startMs).atZone(zone).toLocalDate()
+            .plusDays(days.toLong()).atStartOfDay(zone).toInstant().toEpochMilli()
+
+    /** ISO-8601 with offset in [zone], second precision — e.g. `2026-06-25T15:00:00-07:00`. */
+    fun iso(ms: Long, zone: ZoneId): String =
+        OffsetDateTime.ofInstant(Instant.ofEpochMilli(ms), zone)
+            .withNano(0)
+            .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+
+    /**
+     * Parses an ISO date or datetime into epoch ms, tolerant of the forms a model is likely
+     * to send (a bare `YYYY-MM-DD` snaps to local midnight). Returns null when blank or
+     * unparseable so the caller applies its default.
+     */
+    fun parseBoundary(raw: String?, zone: ZoneId): Long? {
+        val s = raw?.trim().orEmpty()
+        if (s.isEmpty()) return null
+        runCatching { return LocalDate.parse(s).atStartOfDay(zone).toInstant().toEpochMilli() }
+        runCatching { return OffsetDateTime.parse(s).toInstant().toEpochMilli() }
+        runCatching { return Instant.parse(s).toEpochMilli() }
+        runCatching { return LocalDateTime.parse(s).atZone(zone).toInstant().toEpochMilli() }
+        return null
+    }
+}

--- a/app/src/main/java/com/portal/calendar/CalendarToolProvider.kt
+++ b/app/src/main/java/com/portal/calendar/CalendarToolProvider.kt
@@ -1,0 +1,249 @@
+package com.portal.calendar
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.database.Cursor
+import android.net.Uri
+import android.os.Bundle
+import android.text.format.DateFormat
+import org.json.JSONObject
+import java.time.ZoneId
+import java.util.concurrent.Callable
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Exposes the family calendar's upcoming **agenda** to the Portal **assistant** via its
+ * tool provider plugin contract (an exported [ContentProvider] carrying a JSON tool
+ * declaration in its manifest meta-data; the assistant discovers it, the user enables it
+ * once in the assistant's Settings, and invokes it with a synchronous `call`).
+ *
+ * **Why an agenda dump:** a narrow parameterized query made the model guess date ranges /
+ * names blindly and miss things. Instead we hand it the whole upcoming agenda as readable
+ * text and let it reason — the same thing that made pasting the raw iCal accurate, but the
+ * secret feed URL never leaves this process.
+ *
+ * **Privacy:** the iCal feed URLs and credentials never leave the app. We return only the
+ * parsed event content (titles / times / locations / people) — never a URL or token. (This
+ * hides the feed secrets, not event content: an exported provider is readable by any app on
+ * the device, the same exposure as the board already on screen on a family Portal.)
+ *
+ * **Latency:** `call()` answers well inside the assistant's ~5s timeout and never blocks on
+ * the network. It serves [App.lastEvents] (the board's live snapshot), falling back to a
+ * synchronous parse of the on-disk feed caches when the board hasn't synced this process,
+ * and kicks a best-effort background refresh for the *next* call.
+ */
+class CalendarToolProvider : ContentProvider() {
+
+    /** True while a query-triggered background sync is in flight (coalesces refreshes). */
+    private val refreshing = AtomicBoolean(false)
+
+    /** Worker for the bounded offline-cache parse, so a slow parse keeps running past the
+     *  call's deadline (publishing for the next call) instead of blocking the binder thread. */
+    private val cacheParseExec = Executors.newSingleThreadExecutor()
+
+    /** True while a cache parse is in flight (coalesces it, like [refreshing] for syncs):
+     *  a burst of cold retries must not queue a backlog of identical multi-feed parses. */
+    private val cacheParsing = AtomicBoolean(false)
+
+    override fun onCreate(): Boolean = true
+
+    override fun call(method: String, arg: String?, extras: Bundle?): Bundle? {
+        if (method != METHOD_INVOKE) return null
+        val result = runCatching {
+            when (arg) {
+                TOOL_AGENDA -> agenda(JSONObject(extras?.getString(EXTRA_ARGS_JSON) ?: "{}"))
+                else -> JSONObject().put("error", "unknown tool: $arg")
+            }
+        }.getOrElse { JSONObject().put("error", it.message ?: "calendar lookup failed") }
+        return Bundle().apply { putString(EXTRA_RESULT_JSON, result.toString()) }
+    }
+
+    private fun agenda(args: JSONObject): JSONObject {
+        // The call() that wakes a dead PortalHub can land on a binder thread before
+        // App.onCreate finishes; briefly wait for startup (well inside the assistant's
+        // timeout) so the first cold call answers instead of erroring out.
+        val app = awaitApp(STARTUP_WAIT_MS)
+            ?: return JSONObject().put("error", "calendar still starting up, try again")
+        val zone = ZoneId.systemDefault()
+        val now = System.currentTimeMillis()
+        val notes = ArrayList<String>()
+
+        val feeds = app.store.feeds()
+        val calendarNames = feeds.filter { it.kind != "inbox" }.map { it.name }
+
+        // Source the snapshot without ever touching the network.
+        val asOf = app.lastSyncAt
+        var events = app.lastEvents
+        val problems = ArrayList<String>()
+        if (events.isEmpty() && asOf == 0L) {
+            // Board hasn't synced this process — parse the offline caches, but BOUND the wait.
+            events = primeFromCacheBounded(app, problems, CACHE_PARSE_BUDGET_MS)
+        }
+        // Freshen for the next call when cold or the snapshot is getting old.
+        val stale = asOf != 0L && now - asOf > STALE_AFTER_MS
+        if (asOf == 0L || stale) kickBackgroundRefresh(app)
+
+        // Soft notes (never error-shaped): age / "data not loaded yet", a feed that couldn't
+        // be read or hasn't synced (so the model doesn't read it as "nothing scheduled"), a
+        // bad start arg, truncation.
+        freshnessNote(asOf, now, events.isNotEmpty())?.let { notes.add(it) }
+        // Only when we already have *some* data (or a real sync ran) — otherwise the cold
+        // "no saved calendar data yet" note above already covers it.
+        if ((feedDataMissing(problems) || feedDataMissing(app.lastSyncProblems)) &&
+            (asOf != 0L || events.isNotEmpty())
+        ) {
+            notes.add("(some calendars couldn't be loaded, so this agenda may be missing events)")
+        }
+        val startArg = args.optStringOrNull("start")
+        val parsedStart = startArg?.let { CalendarQuery.parseBoundary(it, zone) }
+        if (startArg != null && parsedStart == null) {
+            notes.add("(couldn't read the requested start date \"$startArg\"; showing from today)")
+        }
+
+        // Window: start (parsed date arg, or today's local midnight) .. +days calendar days.
+        val startMs = parsedStart ?: CalendarQuery.startOfToday(now, zone)
+        val days = args.optInt("days", DEFAULT_DAYS).coerceIn(1, MAX_DAYS)
+        var windowed = CalendarQuery.inWindow(events, startMs, CalendarQuery.endAfterDays(startMs, days, zone))
+        if (windowed.size > MAX_AGENDA_EVENTS) {
+            notes.add("(showing the first $MAX_AGENDA_EVENTS events; ask about a specific day or a shorter range for the rest)")
+            windowed = windowed.take(MAX_AGENDA_EVENTS)
+        }
+
+        val use24h = context?.let { DateFormat.is24HourFormat(it) } ?: false
+        val text = AgendaFormatter.format(
+            events = windowed,
+            nowMs = now,
+            windowStartMs = startMs,
+            days = days,
+            zone = zone,
+            use24h = use24h,
+            calendarNames = calendarNames,
+            notes = notes,
+        )
+
+        return JSONObject()
+            .put("agenda", text)
+            .put("generatedAt", CalendarQuery.iso(now, zone))
+    }
+
+    /** Problems that mean a feed's events are MISSING (broken, fetch-failed, or never synced)
+     *  — as opposed to merely stale/cached, which is fine. */
+    private fun feedDataMissing(problems: List<String>): Boolean =
+        problems.any {
+            it.contains("unreadable") || it.contains("fetch failed") ||
+                it.contains("sync failed") || it.contains("no saved data")
+        }
+
+    /** A soft, never-alarming note about data age (so Jarvis won't say "not connected"). */
+    private fun freshnessNote(asOf: Long, now: Long, haveEvents: Boolean): String? = when {
+        asOf == 0L -> if (haveEvents) "(showing the last saved calendar; refreshing now)"
+        else "(no saved calendar data yet; refreshing now)"
+        now - asOf > STALE_AFTER_MS -> "(calendar last updated about ${humanAge(now - asOf)} ago)"
+        else -> null
+    }
+
+    private fun humanAge(ms: Long): String {
+        val min = ms / 60_000
+        return when {
+            min < 90 -> "$min min"
+            min < 60 * 36 -> "${(min + 30) / 60} hours"
+            else -> "${(min + 720) / 1440} days"
+        }
+    }
+
+    /** Waits up to [timeoutMs] for App.onCreate to finish (ready). Safe to block here:
+     *  call() runs on a binder thread and the assistant budgets several seconds. */
+    private fun awaitApp(timeoutMs: Long): App? {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        var app = App.instanceOrNull()
+        while (app == null && System.currentTimeMillis() < deadline) {
+            Thread.sleep(50)
+            app = App.instanceOrNull()
+        }
+        return app
+    }
+
+    /**
+     * Parse the on-disk caches on a worker, waiting at most [budgetMs]. If the parse finishes
+     * in time, return its events (and surface its per-feed problems); if it overruns — a large
+     * feed can take many seconds — return empty and let it keep running: it still publishes to
+     * [App.lastEvents] on completion, so the next call is instant. Coalesced so a burst of cold
+     * retries can't queue a backlog of identical parses.
+     */
+    private fun primeFromCacheBounded(app: App, out: MutableList<String>, budgetMs: Long): List<EventInstance> {
+        if (!cacheParsing.compareAndSet(false, true)) return emptyList()
+        val probs = java.util.Collections.synchronizedList(ArrayList<String>())
+        // submit() inside the guard: if it throws (e.g. RejectedExecutionException) the worker's
+        // finally never runs, so reset the flag here or it would latch true for the whole process.
+        val future = runCatching {
+            cacheParseExec.submit(Callable {
+                try {
+                    val evs = app.sync.eventsFromCache(probs)
+                    // Publish only if still cold, so we can't clobber a real sync that landed
+                    // meanwhile. asOf stays 0: this is cache, not a sync (the kicked refresh sets it).
+                    if (evs.isNotEmpty()) app.onMain {
+                        if (app.lastEvents.isEmpty() && app.lastSyncAt == 0L) app.lastEvents = evs
+                    }
+                    evs
+                } finally {
+                    cacheParsing.set(false)
+                }
+            })
+        }.getOrElse { cacheParsing.set(false); return emptyList() }
+        return runCatching {
+            val evs = future.get(budgetMs, TimeUnit.MILLISECONDS)
+            synchronized(probs) { out.addAll(probs) } // completed in time → surface its problems
+            evs
+        }.getOrDefault(emptyList()) // timed out (or failed) — worker keeps running and publishes
+    }
+
+    /** A query-triggered refresh; coalesced so a burst of cold calls can't queue a
+     *  pile of redundant network syncs on the single-thread sync executor. */
+    private fun kickBackgroundRefresh(app: App) {
+        if (!refreshing.compareAndSet(false, true)) return
+        runCatching {
+            app.sync.requestSync { evs, probs ->
+                app.lastEvents = evs
+                app.lastSyncAt = System.currentTimeMillis()
+                app.lastSyncProblems = probs
+                refreshing.set(false)
+            }
+        }.onFailure { refreshing.set(false) }
+    }
+
+    // --- ContentProvider surface we don't use: this provider only answers call(). ---
+    override fun query(u: Uri, p: Array<out String>?, s: String?, a: Array<out String>?, o: String?): Cursor? = null
+    override fun getType(uri: Uri): String? = null
+    override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+    override fun delete(uri: Uri, s: String?, a: Array<out String>?): Int = 0
+    override fun update(uri: Uri, v: ContentValues?, s: String?, a: Array<out String>?): Int = 0
+
+    private fun JSONObject.optStringOrNull(key: String): String? =
+        if (has(key) && !isNull(key)) optString(key).trim().takeUnless { it.isEmpty() } else null
+
+    companion object {
+        // The Portal assistant tool contract (literal strings — no dependency needed).
+        private const val METHOD_INVOKE = "invoke"
+        private const val EXTRA_ARGS_JSON = "com.portal.assistant.tools.extra.ARGS"
+        private const val EXTRA_RESULT_JSON = "com.portal.assistant.tools.extra.RESULT"
+        private const val TOOL_AGENDA = "com.portal.calendar.get_agenda"
+
+        private const val DEFAULT_DAYS = 14
+        private const val MAX_DAYS = 60
+
+        /** Soft ceiling on event lines per agenda, so a huge range can't bloat the prompt. */
+        private const val MAX_AGENDA_EVENTS = 200
+
+        /** Past this age we note the snapshot's age and trigger a background refresh. */
+        private const val STALE_AFTER_MS = 20L * 60 * 1000
+
+        /** How long a cold call() waits for App startup before giving up (< the
+         *  assistant's ~5s tool timeout, leaving headroom for the lookup itself). */
+        private const val STARTUP_WAIT_MS = 3_000L
+
+        /** How long a cold call() waits for the offline-cache parse before answering "loading". */
+        private const val CACHE_PARSE_BUDGET_MS = 2_000L
+    }
+}

--- a/app/src/main/java/com/portal/calendar/CalendarToolProvider.kt
+++ b/app/src/main/java/com/portal/calendar/CalendarToolProvider.kt
@@ -205,9 +205,7 @@ class CalendarToolProvider : ContentProvider() {
         if (!refreshing.compareAndSet(false, true)) return
         runCatching {
             app.sync.requestSync { evs, probs ->
-                app.lastEvents = evs
-                app.lastSyncAt = System.currentTimeMillis()
-                app.lastSyncProblems = probs
+                app.publishSync(evs, System.currentTimeMillis(), probs)
                 refreshing.set(false)
             }
         }.onFailure { refreshing.set(false) }

--- a/app/src/main/java/com/portal/calendar/Snapshot.kt
+++ b/app/src/main/java/com/portal/calendar/Snapshot.kt
@@ -1,0 +1,49 @@
+package com.portal.calendar
+
+import android.content.Context
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Persists the last parsed agenda (events + sync time) to disk, so a cold start — e.g. an
+ * assistant call that wakes a dead process — answers from the last good data instantly,
+ * without re-parsing every ICS feed (which is too slow for the assistant's timeout).
+ *
+ * Same event content already lives in the plaintext feed_*.ics caches in filesDir, so it
+ * adds no new exposure. Atomic write/read reuse [Data].
+ */
+object Snapshot {
+    private const val FILE = "agenda_snapshot.json"
+
+    data class Loaded(val events: List<EventInstance>, val syncedAt: Long, val problems: List<String>)
+
+    fun save(ctx: Context, events: List<EventInstance>, syncedAt: Long, problems: List<String>) {
+        val arr = JSONArray()
+        for (e in events) arr.put(JSONObject().apply {
+            put("s", e.start); put("e", e.end); put("ad", e.allDay); put("t", e.title)
+            putOpt("loc", e.location); put("fn", e.feedName); put("c", e.color)
+            put("uid", e.uid); put("rec", e.recurring)
+        })
+        val root = JSONObject().put("at", syncedAt).put("events", arr).put("problems", JSONArray(problems))
+        runCatching { Data.writeRaw(ctx, FILE, root.toString()) }
+    }
+
+    fun load(ctx: Context): Loaded? {
+        val root = Data.readObject(ctx, FILE)
+        val arr = root.optJSONArray("events") ?: return null
+        val out = ArrayList<EventInstance>(arr.length())
+        for (i in 0 until arr.length()) {
+            val o = arr.optJSONObject(i) ?: continue
+            out.add(EventInstance(
+                start = o.optLong("s"), end = o.optLong("e"), allDay = o.optBoolean("ad"),
+                title = o.optString("t"), location = o.optString("loc").takeUnless { it.isEmpty() },
+                feedName = o.optString("fn"), color = o.optInt("c"),
+                uid = o.optString("uid"), recurring = o.optBoolean("rec")))
+        }
+        val problems = ArrayList<String>()
+        root.optJSONArray("problems")?.let { p ->
+            for (i in 0 until p.length()) p.optString(i).takeUnless { it.isEmpty() }?.let(problems::add)
+        }
+        return Loaded(out, root.optLong("at", 0L), problems)
+    }
+}

--- a/app/src/main/java/com/portal/calendar/SyncManager.kt
+++ b/app/src/main/java/com/portal/calendar/SyncManager.kt
@@ -39,26 +39,65 @@ class SyncManager(private val ctx: Context, private val store: ConfigStore) {
 
     fun requestSync(onDone: (events: List<EventInstance>, problems: List<String>) -> Unit) {
         executor.execute {
-            val feeds = store.feeds()
             val all = ArrayList<EventInstance>()
             val problems = ArrayList<String>()
-            for (feed in feeds) {
-                val text = fetchWithCache(feed, problems) ?: continue
-                try {
-                    if (feed.kind == "inbox") processInbox(text)
-                    else all.addAll(parseFeed(text, feed))
-                } catch (e: Exception) {
-                    problems.add("${feed.name}: unreadable feed (${e.javaClass.simpleName})")
+            // onDone must ALWAYS fire (in the finally): callers gate state on it — e.g. the
+            // assistant tool's "refresh in flight" flag would latch forever if a throw in
+            // store.feeds()/sort skipped the callback.
+            try {
+                for (feed in store.feeds()) {
+                    val text = fetchWithCache(feed, problems) ?: continue
+                    try {
+                        if (feed.kind == "inbox") processInbox(text)
+                        else all.addAll(parseFeed(text, feed))
+                    } catch (e: Exception) {
+                        problems.add("${feed.name}: unreadable feed (${e.javaClass.simpleName})")
+                    }
                 }
+                all.sortBy { it.start }
+            } catch (e: Exception) {
+                problems.add("sync failed (${e.javaClass.simpleName})")
+            } finally {
+                main.post { onDone(all, problems) }
             }
-            all.sortBy { it.start }
-            main.post { onDone(all, problems) }
         }
+    }
+
+    /** The on-disk offline copy of a feed (one shared naming scheme for read and write). */
+    private fun cacheFile(feed: FeedConfig): File =
+        File(ctx.filesDir, "feed_" + md5(feed.url) + ".ics")
+
+    /**
+     * Parses events straight from the on-disk feed caches — no network, no callback.
+     * Used by the assistant tool provider so a voice query can answer synchronously
+     * within its timeout budget even when the board hasn't run a sync this process.
+     * Returns whatever feeds have a cached copy (empty list if none cached yet);
+     * any feed whose cache won't parse is reported via [problems], not silently dropped.
+     *
+     * Read-only: passes runCommands=false so a voice query never executes magic-word
+     * commands (creating chores/lists) as a side effect — that belongs to a real sync.
+     */
+    fun eventsFromCache(problems: MutableList<String>): List<EventInstance> {
+        val out = ArrayList<EventInstance>()
+        for (feed in store.feeds()) {
+            if (feed.kind == "inbox") continue // commands, never rendered
+            val cache = cacheFile(feed)
+            if (!cache.exists()) {
+                // Never synced this device yet — distinct from "unreadable" so the caller can
+                // tell the model the calendar hasn't loaded rather than that it's broken.
+                problems.add("${feed.name}: no saved data yet")
+                continue
+            }
+            runCatching { out.addAll(parseFeed(cache.readText(), feed, runCommands = false)) }
+                .onFailure { problems.add("${feed.name}: cached copy unreadable") }
+        }
+        out.sortBy { it.start }
+        return out
     }
 
     /** Network first; on failure falls back to the last good copy on disk. */
     private fun fetchWithCache(feed: FeedConfig, problems: MutableList<String>): String? {
-        val cache = File(ctx.filesDir, "feed_" + md5(feed.url) + ".ics")
+        val cache = cacheFile(feed)
         try {
             val url = if (feed.url.startsWith("webcal://"))
                 "https://" + feed.url.removePrefix("webcal://") else feed.url
@@ -92,7 +131,7 @@ class SyncManager(private val ctx: Context, private val store: ConfigStore) {
         }
     }
 
-    private fun parseFeed(text: String, feed: FeedConfig): List<EventInstance> {
+    private fun parseFeed(text: String, feed: FeedConfig, runCommands: Boolean = true): List<EventInstance> {
         val out = ArrayList<EventInstance>()
         val tz = TimeZone.getDefault()
         val now = System.currentTimeMillis()
@@ -119,15 +158,17 @@ class SyncManager(private val ctx: Context, private val store: ConfigStore) {
                 val evUid = e.uid?.value ?: ""
                 if (evUid.isNotEmpty() && evUid in suppressed) continue // deleted from the board
 
-                // Magic-word events route to lists/chores and never render.
+                // Magic-word events route to lists/chores and never render. Executing
+                // them is a write, so only a real sync (runCommands) does it — a
+                // read-only cache parse just skips them.
                 val magic = MagicWords.match(e.summary?.value ?: "")
                 if (magic != null) {
-                    val uid = e.uid?.value ?: (feed.url + (e.summary?.value ?: ""))
-                    // Mark AFTER a successful execute so a failed command
-                    // retries next sync instead of being consumed silently.
-                    if (!MagicWords.isProcessed(ctx, uid)) {
-                        runCatching { MagicWords.execute(ctx, magic, ds.value.time) }
-                            .onSuccess { MagicWords.markProcessed(ctx, uid) }
+                    if (runCommands) {
+                        val uid = e.uid?.value ?: (feed.url + (e.summary?.value ?: ""))
+                        if (!MagicWords.isProcessed(ctx, uid)) {
+                            runCatching { MagicWords.execute(ctx, magic, ds.value.time) }
+                                .onSuccess { MagicWords.markProcessed(ctx, uid) }
+                        }
                     }
                     continue
                 }
@@ -245,6 +286,6 @@ class SyncManager(private val ctx: Context, private val store: ConfigStore) {
             .joinToString("") { "%02x".format(it) }
 
     companion object {
-        const val DAY_MS = 86_400_000L
+        const val DAY_MS = CalendarQuery.DAY_MS // single source of the ms-per-day constant
     }
 }

--- a/app/src/main/res/values/portal_tools.xml
+++ b/app/src/main/res/values/portal_tools.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Tool declaration advertised to the Portal assistant (com.portal.assistant.tools
+  meta-data on CalendarToolProvider). A JSON array of Jarvis function declarations.
+  The assistant reads this as a string resource, so the JSON quotes are escaped (\").
+-->
+<resources>
+    <string name="portal_tools">[{\"name\":\"com.portal.calendar.get_agenda\",\"description\":\"Returns the family calendar as readable text to answer any question.\",\"parameters\":{\"type\":\"OBJECT\",\"properties\":{\"days\":{\"type\":\"INTEGER\",\"description\":\"How many days of agenda to return, starting from start (default 14, max 60).\"},\"start\":{\"type\":\"STRING\",\"description\":\"First day to include, ISO date YYYY-MM-DD. Defaults to today. Use it to look at a specific future day or week.\"}},\"required\":[]}}]</string>
+
+    <string name="portal_tools_summary">Answer questions about the family calendar.</string>
+</resources>


### PR DESCRIPTION
Integrates PortalHub with Jarvis, the Portal assistant, so users can ask about their calendar by voice ("when is my next meeting?", "what's on tomorrow?").

PortalHub exposes a read-only `ContentProvider` (`CalendarToolProvider`) advertising a `com.portal.calendar.get_agenda` tool via the Portal-assistant plugin contract. The assistant discovers it, the user enables it once in assistant Settings, and it returns the upcoming agenda as readable, day-grouped text for the model to reason over. Day headers are anchored with `(today)`/`(tomorrow)` so relative-day questions don't depend on the model's own date arithmetic.

**Commits**
1. **Jarvis integration** — the tool provider, `AgendaFormatter`, `CalendarQuery` (date windowing), manifest + `portal_tools.xml` registration, and the read-only `eventsFromCache` path.
2. **Snapshot persistence** — after each sync the parsed agenda is persisted; at startup it's primed before the tool is ready, so a cold call (a process the assistant just woke) answers with real data (~1.1s) instead of re-parsing every feed (which exceeds the assistant's timeout).

**Privacy:** iCal feed URLs and credentials never leave the app; only parsed event content (titles/times/locations) is returned — the same data already on the board. The user must enable the tool in Jarvis settings.

**Verified on a Portal+:** warm and cold calls return the full agenda; `days`/`start` args, capping, and bad-input notes behave; event placement cross-checked against the events' real timestamps (0 day-mismatches); no feed URLs or credentials in the output.

More about Jarvis: https://www.reddit.com/r/FacebookPortal/s/dFZlWzhfqn

🤖 Generated with [Claude Code](https://claude.com/claude-code)